### PR TITLE
Allow empty baseUri, fix base_uri setting in Symfony Bundle

### DIFF
--- a/src/DefaultRestClient.php
+++ b/src/DefaultRestClient.php
@@ -33,41 +33,49 @@ final class DefaultRestClient implements RestClientInterface
     ) {
     }
 
+    /** @throws ExpectedBaseUri */
     public function get(string|null $uri = null, array|null $uriVariables = null): RequestHeadersSpec
     {
         return $this->createHeadersSpec('GET', $this->createUriFactory($uri, $uriVariables));
     }
 
+    /** @throws ExpectedBaseUri */
     public function head(string|null $uri = null, array|null $uriVariables = null): RequestHeadersSpec
     {
         return $this->createHeadersSpec('HEAD', $this->createUriFactory($uri, $uriVariables));
     }
 
+    /** @throws ExpectedBaseUri */
     public function post(string|null $uri = null, array|null $uriVariables = null): RequestBodyHeadersSpec
     {
         return $this->createBodyHeadersSpec('POST', $this->createUriFactory($uri, $uriVariables));
     }
 
+    /** @throws ExpectedBaseUri */
     public function put(string|null $uri = null, array|null $uriVariables = null): RequestBodyHeadersSpec
     {
         return $this->createBodyHeadersSpec('PUT', $this->createUriFactory($uri, $uriVariables));
     }
 
+    /** @throws ExpectedBaseUri */
     public function patch(string|null $uri = null, array|null $uriVariables = null): RequestBodyHeadersSpec
     {
         return $this->createBodyHeadersSpec('PATCH', $this->createUriFactory($uri, $uriVariables));
     }
 
+    /** @throws ExpectedBaseUri */
     public function delete(string|null $uri = null, array|null $uriVariables = null): RequestHeadersSpec
     {
         return $this->createHeadersSpec('DELETE', $this->createUriFactory($uri, $uriVariables));
     }
 
+    /** @throws ExpectedBaseUri */
     public function options(string|null $uri = null, array|null $uriVariables = null): RequestHeadersSpec
     {
         return $this->createHeadersSpec('OPTIONS', $this->createUriFactory($uri, $uriVariables));
     }
 
+    /** @param non-empty-string $method */
     protected function createHeadersSpec(string $method, UriFactory $uriFactory): RequestHeadersSpec
     {
         return new RequestHeadersSpec(
@@ -80,6 +88,7 @@ final class DefaultRestClient implements RestClientInterface
         );
     }
 
+    /** @param non-empty-string $method */
     protected function createBodyHeadersSpec(string $method, UriFactory $uriFactory): RequestBodyHeadersSpec
     {
         return new RequestBodyHeadersSpec(
@@ -92,10 +101,15 @@ final class DefaultRestClient implements RestClientInterface
         );
     }
 
+    /** @throws ExpectedBaseUri */
     protected function createUriFactory(string|null $uri, array|null $uriVariables): UriFactory
     {
-        if ($this->baseUrl) {
-            if (str_ends_with($this->baseUrl, '/') && str_starts_with($uri, '/')) {
+        if ($this->baseUrl === null && $uri === null) {
+            throw new ExpectedBaseUri('Not passing Uri if no baseUri defined on client is not allowed');
+        }
+
+        if (! empty($this->baseUrl)) {
+            if (str_ends_with($this->baseUrl, '/') && $uri && str_starts_with($uri, '/')) {
                 $uri = ltrim($uri, '/');
             }
 

--- a/src/DefaultRestClientBuilder.php
+++ b/src/DefaultRestClientBuilder.php
@@ -37,7 +37,7 @@ final class DefaultRestClientBuilder implements RestClientBuilderInterface
     ) {
     }
 
-    public function baseUrl(string $url): static
+    public function baseUrl(string|null $url): static
     {
         $this->baseUrl = $url;
 

--- a/src/ExpectedBaseUri.php
+++ b/src/ExpectedBaseUri.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brzuchal\RestClient;
+
+use Exception;
+
+final class ExpectedBaseUri extends Exception
+{
+}

--- a/src/RestClient.php
+++ b/src/RestClient.php
@@ -13,8 +13,9 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class RestClient
 {
+    /** @param non-empty-string|null $baseUri */
     public static function create(
-        string $baseUri,
+        string|null $baseUri,
         HttpClientInterface|null $httpClient = null,
         SerializerInterface|null $serializer = null,
     ): RestClientInterface {

--- a/src/RestClientBuilderInterface.php
+++ b/src/RestClientBuilderInterface.php
@@ -12,11 +12,11 @@ interface RestClientBuilderInterface
     /**
      * Specify a base URI for all requests using the URI template.
      *
-     * @param non-empty-string $url
+     * @param non-empty-string|null $url
      *
      * @return $this
      */
-    public function baseUrl(string $url): static;
+    public function baseUrl(string|null $url): static;
 
     /**
      * Specify a base URI template list of variables.


### PR DESCRIPTION
| Q             | A                                                       |
|---------------|---------------------------------------------------------|
| Branch?       | 1.0                                                     |
| Bug fix?      | yes                                                  |
| New feature?  | no <!-- please update src/**/CHANGELOG.md files --> |

## Changed
- Symfony Bundle config value of `base_uri` was incorrectly bound to container parameter causing an error
- Setting default `base_uri` is now not required and may be null

