### PR TITLE
Fix skipped base_uri param

### DIFF
--- a/src/RestClientBundle.php
+++ b/src/RestClientBundle.php
@@ -70,7 +70,7 @@ final class RestClientBundle extends AbstractBundle
             }
 
             $baseUriParam = $id . '.base_uri';
-            $container->parameters()->set($baseUriParam, $values['base_uri']);
+            $container->parameters()->set($baseUriParam, $values['base_uri'] ?? null);
             $httpClient    = ! empty($values['http_client']) ? new Reference($values['http_client']) : null;
             $serializer    = ! empty($values['serializer']) ? new Reference($values['serializer']) : null;
             $clientService = $container->services()->set($id, RestClientInterface::class);


### PR DESCRIPTION
| Q             | A                                                       |
|---------------|---------------------------------------------------------|
| Branch?       | 1.0                                                     |
| Bug fix?      | yes                                                  |
| New feature?  | no <!-- please update src/**/CHANGELOG.md files --> |

## Fixed
- Symfony Bundle `base_uri` config even though allowed to be null was unexpectedly needed by wiring 
